### PR TITLE
Improve sqlite3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "redis": "^0.12.1",
     "sequelize": "~1.7.10",
     "socket.io": "~1.1.0",
-    "sqlite3": "-3.0.5"
+    "sqlite3": "~3.0.5"
   },
   "devDependencies": {
     "express-generator": "~4.9.0",


### PR DESCRIPTION
インストール時に
"No compatible version found: sqlite3@-3.0.5" 
のエラーが出てしまうため、バージョン表記を修正しました。